### PR TITLE
Added renderFile

### DIFF
--- a/lib/haml.js
+++ b/lib/haml.js
@@ -666,7 +666,6 @@ exports.render = function(str, options) {
   }).call(options.context)
 }
 
-
 /**
  * Render a file containing haml and cache the parser.
  *
@@ -681,19 +680,19 @@ exports.render = function(str, options) {
 exports.renderFile = function(filename, encoding, options, callback) {
     options = options || {}
     options.filename = options.filename || filename
-    options.cache = true
+    options.cache = options.hasOwnProperty('cache') ? options.cache : true
 
-    if (!exports.cache[filename]) {
+    if (exports.cache[filename]) {
+        process.nextTick(function() {
+            callback(null, exports.render(null, options))
+        });
+    } else {
         fs.readFile(filename, encoding, function(err, str) {
             if (err) {
                 callback(err)
             } else {
                 callback(null, exports.render(str, options))
             }
-        });
-    } else {
-        process.nextTick(function() {
-            callback(null, exports.render(null, options))
         });
     }
 }

--- a/lib/haml.js
+++ b/lib/haml.js
@@ -6,6 +6,7 @@
  */
 
 var sys = require('sys')
+var fs = require('fs')
 
 /**
  * Version.
@@ -663,4 +664,36 @@ exports.render = function(str, options) {
       throw err
     }
   }).call(options.context)
+}
+
+
+/**
+ * Render a file containing haml and cache the parser.
+ *
+ * @param  {string} filename
+ * @param  {string} encoding
+ * @param  {object} options
+ * @param  {function} callback
+ * @return {void}
+ * @api public
+ */
+
+exports.renderFile = function(filename, encoding, options, callback) {
+    options = options || {}
+    options.filename = options.filename || filename
+    options.cache = true
+
+    if (!exports.cache[filename]) {
+        fs.readFile(filename, encoding, function(err, str) {
+            if (err) {
+                callback(err)
+            } else {
+                callback(null, exports.render(str, options))
+            }
+        });
+    } else {
+        process.nextTick(function() {
+            callback(null, exports.render(null, options))
+        });
+    }
 }


### PR DESCRIPTION
The renderFile function allows you to specify a filename to be rendered.

The function automatically caches the parser function and will use it the next time the same file is rendered.

It is incredibly useful when your haml templates are stored in files.

```
    haml.renderFile('layout.haml', 'utf8', options, function(err, data) {
        if (!err) {
            // stuff
        } else {
            // stuff
        }
    });
```
