### PR TITLE
Expose Parser for extension

### DIFF
--- a/lib/haml.js
+++ b/lib/haml.js
@@ -261,7 +261,7 @@ function template(name, vals) {
  * Initialize parser with _str_ and _options_.
  */
 
-function Parser(str, options) {
+exports.Parser = Parser = function (str, options) {
   options = options || {}
   this.tokens = tokenize(str)
   this.xml = options.xml

--- a/spec/unit/spec.js
+++ b/spec/unit/spec.js
@@ -13,6 +13,12 @@ describe 'haml'
     end
   end
 
+  describe 'Parser'
+    it 'should be available for extension'
+      haml.Parser.should.not.be_undefined
+    end
+  end
+
   describe '.render()'
     before
       assertAs = function(name, type, options) {


### PR DESCRIPTION
This allows for the parser to be extended (e.g. I'm writing a coffeescript extension to the code pieces of hamljs)
