### PR TITLE
Supported newlines

### DIFF
--- a/lib/haml.js
+++ b/lib/haml.js
@@ -198,7 +198,7 @@ function tokenize(str) {
       tokens = [],
       line = 1,
       lastIndents = 0,
-      str = String(str).trim().replace(/\r\n|\r/g, '\n')
+      str = String(str).trim().replace(/\r\n|\r|\n *\n/g, '\n')
   function error(msg){ throw new HamlError('(Haml):' + line + ' ' + msg) }
   while (str.length) {
     for (var type in rules)

--- a/spec/fixtures/newlines.whitespace.haml
+++ b/spec/fixtures/newlines.whitespace.haml
@@ -1,0 +1,4 @@
+%head
+  %title
+             
+    tabineko

--- a/spec/fixtures/newlines.whitespace.html
+++ b/spec/fixtures/newlines.whitespace.html
@@ -1,0 +1,2 @@
+<head>
+<title>tabineko</title></head>

--- a/spec/fixtures/newlines.within-tags.haml
+++ b/spec/fixtures/newlines.within-tags.haml
@@ -1,0 +1,4 @@
+%head
+  %title
+
+    kunoichi

--- a/spec/fixtures/newlines.within-tags.html
+++ b/spec/fixtures/newlines.within-tags.html
@@ -1,0 +1,2 @@
+<head>
+<title>kunoichi</title></head>

--- a/spec/unit/spec.js
+++ b/spec/unit/spec.js
@@ -89,8 +89,18 @@ describe 'haml'
       assert('tag.simple', { cache: true, filename: 'tag.simple.haml' })
     end
     
-    it 'should support blank lines'
-      assert('newlines')
+    describe '\n'
+      it 'should support blank lines'
+        assert('newlines')
+      end
+
+      it 'should support blank lines within tags'
+        assert('newlines.within-tags')
+      end
+
+      it 'should support blank lines filled in whitespace'
+        assert('newlines.whitespace')
+      end
     end
     
     describe '.class'


### PR DESCRIPTION
I tried to compile the following haml:

``` haml
%head
  %title

    hi
```

expected:

``` html
<head>
<title>hi</title></head>
```

but actual:

``` sh
HamlError: (Haml):4 invalid indentation; got 2, when previous was 0
```

This patch supports newlines and lines filled in whitespace only.
