### PR TITLE
Include support for the latest stable

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
   "author": "TJ Holowaychuk <tj@vision-media.ca> (http://tjholowaychuk.com)",
   "main": "index",
   "engines": {
-    "node": "0.4.x"
+    "node": ">= 0.4.0 < 0.7.0"
   }
 }


### PR DESCRIPTION
The latest stable express `2.5.1` won't install on node `0.6.x` because the hamljs dependency requires node `0.4.x`.

```
npm info uninstall express@2.5.1
npm info postuninstall express@2.5.1
npm ERR! error rolling back express@2.5.1 Error: UNKNOWN, unknown error '/Users/chris/Documents/.../node_modules/express'
npm ERR! Unsupported
npm ERR! Not compatible with your version of node/npm: hamljs@0.5.1
npm ERR! Required: {"node":"0.4.x"}
npm ERR! Actual:   {"npm":"1.0.106","node":"0.6.1"}
npm ERR! 
npm ERR! System Darwin 11.2.0
npm ERR! command "node" "/usr/local/bin/npm" "install" "express"
npm ERR! cwd /Users/chris/Documents/...
npm ERR! node -v v0.6.1
npm ERR! npm -v 1.0.106
npm ERR! code ENOTSUP
```
