### PR TITLE
Fix so `require` works

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-lib/haml.js
+module.exports = require('./lib/haml.js')


### PR DESCRIPTION
With the existing index.js, `require('hamljs')` throws an error.  Fixed to work like e.g. express does it.
