### PR TITLE
'sys' renamed to 'util' for node 0.6.1+ silent warning fix

### DIFF
--- a/lib/haml.js
+++ b/lib/haml.js
@@ -5,7 +5,7 @@
  * Module dependencies.
  */
 
-var sys = require('sys')
+var sys = require('util')
 
 /**
  * Version.

--- a/spec/lib/jspec.js
+++ b/spec/lib/jspec.js
@@ -1752,7 +1752,7 @@
   if (typeof GLOBAL === 'object' && typeof exports === 'object') {
     var fs = require('fs')
     quit = process.exit
-    print = require('sys').puts
+    print = require('util').puts
     readFile = function(file){
       return fs.readFileSync(file).toString('utf8')
     }

--- a/spec/node.js
+++ b/spec/node.js
@@ -1,8 +1,8 @@
 
-require.paths.unshift('spec', './spec/lib', 'lib')
-require('jspec')
-require('unit/spec.helper')
-haml = require('haml')
+// require.paths.unshift('spec', './spec/lib', 'lib')
+haml = require('../lib/haml')
+require('./lib/jspec')
+require('./unit/spec.helper')
 
 JSpec
   .exec('spec/unit/spec.js')


### PR DESCRIPTION
To make sure the tests passed, I also updated spec/node.js to not use requires.paths.unshift, which apparently is not longer supported.
