### PR TITLE
Fix global leak of Parser

### DIFF
--- a/lib/haml.js
+++ b/lib/haml.js
@@ -1,4 +1,3 @@
-
 // Haml - Copyright TJ Holowaychuk <tj@vision-media.ca> (MIT Licensed)
 
 /**
@@ -260,7 +259,7 @@ function template(name, vals) {
  * Initialize parser with _str_ and _options_.
  */
 
-exports.Parser = Parser = function (str, options) {
+var Parser = exports.Parser = function (str, options) {
   options = options || {}
   this.tokens = tokenize(str)
   this.xml = options.xml


### PR DESCRIPTION
This will fix the error in the consolidate.js test where it gives the error message:

```
Error: global leak detected: Parser
```
