### PR TITLE
Report syntax error position for tag attributes

### DIFF
--- a/lib/haml.js
+++ b/lib/haml.js
@@ -5,6 +5,7 @@
  */
 
 var sys = require('util')
+var check = require('syntax-error')
 
 /**
  * Version.
@@ -211,6 +212,11 @@ function tokenize(str) {
             : captures[1]
         }
         str = str.substr(captures[0].length)
+        if (type === 'attrs') {
+          var errmsg = checkjs(token.match)
+          if (errmsg)
+            error(errmsg)
+        }
         if (type === 'indent') ++line
         else  break
         var indents = token.val.length / 2
@@ -251,6 +257,22 @@ function template(name, vals) {
   for (var key in vals)
     buf = buf.replace(new RegExp(key, 'g'), vals[key])
   return buf
+}
+
+/**
+ * Check JS snippet is syntactically correct.
+ *
+ * @param  {string} haml embeddable js snippet
+ * @return {string} err message or undefined
+ * @api private
+ */
+
+function checkjs(src) {
+  var assignTo = "x="  // syntax error without this
+  var err = check(assignTo + src)
+  if (err)
+    return 'SyntaxError ' + err.toString().replace(/\(anonymous file\):[0-9]*/, "").replace(assignTo,"")
+  return 
 }
 
 // --- Parser

--- a/package.json
+++ b/package.json
@@ -7,5 +7,8 @@
     "url": "git://github.com/visionmedia/haml.js.git"
   },
   "author": "TJ Holowaychuk <tj@vision-media.ca> (http://tjholowaychuk.com)",
-  "main": "lib/haml.js"
+  "main": "lib/haml.js",
+  "dependencies": {
+    "syntax-error": "0.0.1"
+  }
 }

--- a/spec/fixtures/tag.attrs.badsyntax.haml
+++ b/spec/fixtures/tag.attrs.badsyntax.haml
@@ -1,0 +1,1 @@
+%option{ value: 'poo }

--- a/spec/fixtures/tag.attrs.badsyntax.html
+++ b/spec/fixtures/tag.attrs.badsyntax.html
@@ -1,0 +1,5 @@
+(Haml):1 SyntaxError 
+
+{ value: 'poo }
+                 ^
+ParseError: Unexpected token ILLEGAL

--- a/spec/unit/spec.js
+++ b/spec/unit/spec.js
@@ -183,6 +183,19 @@ describe 'haml'
       it 'should allow booleans'
         assert('tag.attrs.bools')
       end
+
+      it 'should report syntax error'
+        try {
+          assert('tag.attrs.badsyntax')
+          fail('no syntax error reported')
+        } catch (err) {
+          expected = fixture('tag.attrs.badsyntax.html').trim()
+          if (err.message === expected)
+            pass()
+          else
+            fail('got:\n' + err.message + '\n\nexpected:\n' + expected)
+         }
+      end
     end
     
     describe '!!!'


### PR DESCRIPTION
Syntax errors on tag attributes result in Function() throwing an error. No information indicating error position is shown. This change checks the js first and reports the error and position if syntax is bad.
