### PR TITLE
Allow brackets between quote marks

### DIFF
--- a/haml.js
+++ b/haml.js
@@ -68,7 +68,7 @@ var rules = {
     code: /^\-([^\n]+)/,
     outputCode: /^!=([^\n]+)/,
     escapeCode: /^=([^\n]+)/,
-    attrs: /^\{(.*?)\}/,
+    attrs: /^\{(.*?['"]?.*)\}/,
     tag: /^%([-a-zA-Z][-a-zA-Z0-9:]*)/,
     class: /^\.([\w\-]+)/,
     id: /^\#([\w\-]+)/,

--- a/lib/haml.js
+++ b/lib/haml.js
@@ -120,7 +120,7 @@ var rules = {
   code: /^\-([^\n]+)/,
   outputCode: /^!=([^\n]+)/,
   escapeCode: /^=([^\n]+)/,
-  attrs: /^\{(.*?)\}/,
+  attrs: /^\{(.*?['"]?.*)\}/,
   tag: /^%([-a-zA-Z][-a-zA-Z0-9:]*)/,
   class: /^\.([\w\-]+)/,
   id: /^\#([\w\-]+)/,

--- a/test/fixtures/tag.attrs.brackets.haml
+++ b/test/fixtures/tag.attrs.brackets.haml
@@ -1,0 +1,2 @@
+%a{ href: '/', title: '{{title}}' }
+%a{ href: '/', title: 'the title is {{title}} !' }

--- a/test/fixtures/tag.attrs.brackets.html
+++ b/test/fixtures/tag.attrs.brackets.html
@@ -1,0 +1,2 @@
+<a href="/" title="{{title}}"></a>
+<a href="/" title="the title is {{title}} !"></a>

--- a/test/test.js
+++ b/test/test.js
@@ -207,6 +207,10 @@ describe('haml', function () {
       it('should allow booleans', function () {
         assert('tag.attrs.bools');
       });
+
+      it('should allow brackets between quote marks', function () {
+        assert('tag.attrs.brackets');
+      });
     });
 
     describe('!!!', function () {


### PR DESCRIPTION
Answer to issues #30, #34, #62 and personal uses.
Allow to use curly brackets in string in the array of attributes.

Like this : 
`%a{ href: '/', title: 'the title is {{title}} !' }`
