### PR TITLE
string interpolation and attribute parsing

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -225,7 +225,7 @@ extended simply by adding values to to _haml.doctypes_.
 
 ## String interpolation
 
-    %div Hello #{world}
+    %div Hello #{world}#
 
 with locals:
 

--- a/lib/haml.js
+++ b/lib/haml.js
@@ -120,7 +120,7 @@ var rules = {
   code: /^\-([^\n]+)/,
   outputCode: /^!=([^\n]+)/,
   escapeCode: /^=([^\n]+)/,
-  attrs: /^\{((?:(?:(?!\}).)+)(?:(?:\}\})?(?:(?:(?!\}).)+))+)\}(?!\})/, // all credit goes to github.com/onlinecop for this beastly monstrous thing.
+  attrs: /^\{((?:(?:(?!\}).)+)(?:(?:\}\}|\}')?(?:(?:(?!\}).)+))+)\}(?!\})/, // all credit goes to github.com/onlinecop for this beastly monstrous thing.
   tag: /^%([-a-zA-Z][-a-zA-Z0-9:]*)/,
   class: /^\.([\w\-]+)/,
   id: /^\#([\w\-]+)/,

--- a/lib/haml.js
+++ b/lib/haml.js
@@ -120,7 +120,7 @@ var rules = {
   code: /^\-([^\n]+)/,
   outputCode: /^!=([^\n]+)/,
   escapeCode: /^=([^\n]+)/,
-  attrs: /^\{((?:(?:(?!\}).)+)(?:(?:\}\}|\}')?(?:(?:(?!\}).)+))+)\}(?!\})/, // all credit goes to github.com/onlinecop for this beastly monstrous thing.
+  attrs: /^\{((?:(?:(?!\}).)+)(?:(?:\}\}|\}')?(?:(?:(?!\}).)*))+)\}(?!\})/, // all credit goes to github.com/onlinecop for this beastly monstrous thing.
   tag: /^%([-a-zA-Z][-a-zA-Z0-9:]*)/,
   class: /^\.([\w\-]+)/,
   id: /^\#([\w\-]+)/,

--- a/lib/haml.js
+++ b/lib/haml.js
@@ -120,7 +120,7 @@ var rules = {
   code: /^\-([^\n]+)/,
   outputCode: /^!=([^\n]+)/,
   escapeCode: /^=([^\n]+)/,
-  attrs: /^\{(.*?['"]?.*)\}/,
+  attrs: /^\{((?:(?:(?!\}).)+)(?:(?:\}\})?(?:(?:(?!\}).)+))+)\}(?!\})/, // all credit goes to github.com/onlinecop for this beastly monstrous thing.
   tag: /^%([-a-zA-Z][-a-zA-Z0-9:]*)/,
   class: /^\.([\w\-]+)/,
   id: /^\#([\w\-]+)/,
@@ -255,7 +255,7 @@ Parser.prototype = {
     var text = this.advance.val.trim();
 
     // String interpolation
-    text = text.replace(/#\{(.*?)\}/g, '" + $1 + "')
+    text = text.replace(/#\{(.*?)\}#/g, '" + $1 + "')
 
     this.buffer(text)
   },

--- a/test/fixtures/string.complex-interpolation.haml
+++ b/test/fixtures/string.complex-interpolation.haml
@@ -1,1 +1,1 @@
-%p yay #{message + " {oh noes} y u do dis to me"}
+%p yay #{message + " {oh noes} y u do dis to me"}#

--- a/test/fixtures/string.interpolation.haml
+++ b/test/fixtures/string.interpolation.haml
@@ -1,1 +1,1 @@
-%p yay #{message}
+%p yay #{message}#

--- a/test/fixtures/string.multiple-interpolation.haml
+++ b/test/fixtures/string.multiple-interpolation.haml
@@ -1,1 +1,1 @@
-%p yay #{message} - #{stuff}
+%p yay #{message}# - #{stuff}#

--- a/test/fixtures/tag.attrs.brackets.single.haml
+++ b/test/fixtures/tag.attrs.brackets.single.haml
@@ -1,0 +1,2 @@
+%a{ href: '/', title: '{title : this}' }
+%a{ href: '/', title: '{hello: world.grass == undefined}' }

--- a/test/fixtures/tag.attrs.brackets.single.html
+++ b/test/fixtures/tag.attrs.brackets.single.html
@@ -1,0 +1,2 @@
+<a href="/" title="{title : this}"></a>
+<a href="/" title="{hello: world.grass == undefined}"></a>

--- a/test/fixtures/tag.text.block.brackets.haml
+++ b/test/fixtures/tag.text.block.brackets.haml
@@ -1,0 +1,4 @@
+%p
+  hi
+  {{ my bracket expr }}
+  there

--- a/test/fixtures/tag.text.block.brackets.html
+++ b/test/fixtures/tag.text.block.brackets.html
@@ -1,0 +1,1 @@
+<p>hi {{ my bracket expr }} there</p>

--- a/test/fixtures/tag.text.brackets.haml
+++ b/test/fixtures/tag.text.brackets.haml
@@ -1,0 +1,3 @@
+%p {{ my bracket expr }}
+
+%p fdsafdsafds {{ surprise brackets }}

--- a/test/fixtures/tag.text.brackets.html
+++ b/test/fixtures/tag.text.brackets.html
@@ -1,0 +1,2 @@
+<p>{{ my bracket expr }}</p>
+<p>fdsafdsafds {{ surprise brackets }}</p>

--- a/test/test.js
+++ b/test/test.js
@@ -218,6 +218,10 @@ describe('haml', function () {
       it('should allow brackets between quote marks', function () {
         assert('tag.attrs.brackets');
       });
+
+      it('should allow single bracket between quote marks', function () {
+        assert('tag.attrs.brackets.single');
+      });
     });
 
     describe('!!!', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -152,6 +152,14 @@ describe('haml', function () {
       it('should allow empty tags', function () {
         assert('tag.empty');
       });
+
+      it('should work with brackets in the text', function () {
+        assert('tag.text.brackets');
+      });
+
+      it('should work with brackets in a block', function () {
+        assert('tag.text.block.brackets');
+      });
     });
 
     describe('%tag.class', function () {


### PR DESCRIPTION
made string interpolation parsing robust. fixed attribute parsing so it can handle complex bracket expressions and comply with single line HAML syntax

Added tests for the new syntax parsing capabilities, they pass.

I realize that changing the syntax for string interpolation is technically a breaking change but consider this:

1) The test was failing for it in the latest version anyway and it's clear that the parse rules for detecting complex interpolations without a more clear tail delimiter were going to be complicated.
2) It's tiny change that can easily be adapted with a quick project-wide find and replace across your template files.
