### PR TITLE
Fixed: allow empty attributes (ie: `ui-view`)

### DIFF
--- a/lib/haml.js
+++ b/lib/haml.js
@@ -609,7 +609,7 @@ function attrs(attrs) {
     if (typeof finalAttrs[key] === 'boolean') {
       if (finalAttrs[key] === true)
         buf.push(key + '="' + key + '"')
-    } else if (finalAttrs[key])
+    } else
       buf.push(key + '="' + escape(finalAttrs[key]) + '"')
   return buf.join(' ')
 }


### PR DESCRIPTION
make this possible: `%div{"ui-view": ""}`
